### PR TITLE
Adds/clarifies translation docs

### DIFF
--- a/pages/for_developers/pages.md
+++ b/pages/for_developers/pages.md
@@ -13,6 +13,7 @@ The graphics kit improves on our previous [graphics rig](https://github.com/reut
 - [How to make pages and embeds](#how-to-make-pages-and-embeds)
 - [Public pages](#public-pages)
 - [Embeds](#embeds)
+- [Notion page on embeds with an embeddable ai2svelte example](https://www.notion.so/Embeds-for-pages-798975a207424c1ab4df6960905f0bc6?pvs=4)
 
 ## How to make pages and embeds
 

--- a/pages/for_developers/translation.md
+++ b/pages/for_developers/translation.md
@@ -71,7 +71,7 @@ Inside each `+page.svelte`, import the correct content for its translation and p
 <!-- 🇬🇧 pages/+page.svelte -->
 <script>
   import content from '$locales/en/content.json';
-  import MyPage from '$lib/MyPage/index.svelte';
+  import App from '$lib/App/index.svelte';
 </script>
 
 <App content="{content}" />
@@ -81,7 +81,7 @@ Inside each `+page.svelte`, import the correct content for its translation and p
 <!-- 🇩🇪 pages/de/+page.svelte -->
 <script>
   import content from '$locales/de/content.json';
-  import MyPage from '$lib/MyPage/index.svelte';
+  import App from '$lib/App/index.svelte';
 </script>
 
 <App content="{content}" lang="{'de'}" />

--- a/pages/for_developers/translation.md
+++ b/pages/for_developers/translation.md
@@ -187,7 +187,7 @@ To do that, use `.toLocaleString()` instead of `apDate()` and pass in these prop
 
 ## Note on uploading to RNGS
 
-In this rig, we no longer upload and publish separate packs for translated interactive pages. To share translated pages, simply add the `lang` prop at the end of the URl.
+In this rig, we no longer upload and publish [separate editions](https://github.com/reuters-graphics/bluprint_graphics-kit/issues/1#issuecomment-811891029) for translated interactive pages. To share translated pages, simply add the `lang` prop at the end of the URl.
 
 For example, if this is the URL for the English interactive page:
 `https://www.reuters.com/graphics/PERU-PROTEST/ROADBLOCK/zgpobnbwavd/`

--- a/pages/for_developers/translation.md
+++ b/pages/for_developers/translation.md
@@ -98,6 +98,32 @@ And the common component `App.svelte` can use the correct translated text passed
 <h1>{content.greeting}</h1>
 ```
 
+## Embeds
+
+Make sure you remember to import the google doc content and pass it into `App.svelte` in `pages/embeds/en/page/+page.svelte`:
+
+```svelte
+<!-- 🇬🇧 Embed page: pages/embeds/en/page/+page.svelte -->
+<script>
+  import content from '$locales/de/content.json';
+  import App from '$lib/App/index.svelte';
+</script>
+
+<App content="{content}" />
+```
+
+If you make translated version of embed pages, remember to do the same:
+
+```svelte
+<!-- 🇩🇪 Embed page: pages/embeds/de/page/+page.svelte -->
+<script>
+  import content from '$locales/de/content.json';
+  import App from '$lib/App/index.svelte';
+</script>
+
+<App content="{content}" lang="{'de'}" />
+```
+
 ## Translating dateline and byline
 
 Use the `lang` prop passed into `App.svelte` and an `if/else` statement to add translations for words such as "Published" and "By".

--- a/pages/for_developers/translation.md
+++ b/pages/for_developers/translation.md
@@ -12,7 +12,19 @@ This kit does not include any built-in translation utilities like `gettext`. Ins
 
 Let's use a simple example.
 
-Say you have translated content in your locales folder:
+Say you want to add a translated content to your project. First, add the translated google doc, in this case for `de` (🇩🇪), to `google.json`:
+
+```javascript
+// google.json
+{
+  "docs": {
+    "locales/en/content.json": "1sm_YdKj2VHYdqCG7EG3dus-2n6C-cXE1YwfGP-Sg4zQ",
+    "locales/de/content.json": // Add google doc ID for your translated content here
+  },
+}
+```
+
+Once you run `yarn get-google`, you will see the translated content in your locales folder:
 
 ```bash
 locales/
@@ -53,38 +65,109 @@ pages/
 
 ```
 
-Now each page can import the correct content for its translation and pass it to a common component:
+Inside each `+page.svelte`, import the correct content for its translation and pass it to a common component and pass the `lang` prop. If no `lang` prop is passed, it defaults to `en`:
 
 ```svelte
-<!-- 🇬🇧 pages/index.svelte -->
+<!-- 🇬🇧 pages/+page.svelte -->
 <script>
   import content from '$locales/en/content.json';
   import MyPage from '$lib/MyPage/index.svelte';
 </script>
 
-<MyPage content="{content}" />
+<App content="{content}" />
 ```
 
 ```svelte
-<!-- 🇩🇪 pages/de/index.svelte -->
+<!-- 🇩🇪 pages/de/+page.svelte -->
 <script>
   import content from '$locales/de/content.json';
   import MyPage from '$lib/MyPage/index.svelte';
 </script>
 
-<MyPage content="{content}" />
+<App content="{content}" lang="{'de'}" />
 ```
 
-And the common component `MyPage` can use the correct translated text passed to it:
+And the common component `App.svelte` can use the correct translated text passed to it:
 
 ```svelte
-<!-- src/lib/MyPage/index.svelte -->
+<!-- src/lib/App.svelte -->
 <script>
   export let content;
 </script>
 
 <h1>{content.greeting}</h1>
 ```
+
+## Translating dateline and byline
+
+Use the `lang` prop passed into `App.svelte` and an `if/else` statement to add translations for words such as "Published" and "By".
+If you're translating the byline into Spanish, change "By" to "Por:
+
+```svelte
+<!-- src/lib/App.svelte -->
+<script>
+  export let content;
+</script>
+
+<Headline section="{content.Kicker}" hed="{content.Hed}" dek="{content.Dek}">
+  <span slot="byline">
+    {#if lang === 'en'}
+      By {@html marked.parseInline(content.Byline)}
+    {:else if lang === 'es'}
+      🇪🇸 Por {@html marked.parseInline(content.Byline)}
+    {/if}
+  </span>
+</Headline>
+```
+
+You'd also want to make sure the published dateline is translated into the language you want.
+To do that, use `.toLocaleString()` instead of `apDate()` and pass in these props:
+
+- The [correct locale parameter](https://www.w3schools.com/jsref/jsref_tolocalestring.asp) for your language. For Spanish, use `es-ES`. For standard German, for example, use `de-DE`.
+- This object of options that will make sure the month is spelled out and the day and year will show up as numbers:
+  ` { year: 'numeric', month: 'long', day: 'numeric', }`
+
+```svelte
+<!-- src/lib/App.svelte -->
+<script>
+  export let content;
+</script>
+
+<Headline section="{content.Kicker}" hed="{content.Hed}" dek="{content.Dek}">
+  <span slot="byline">
+    {#if lang === 'en'}
+      By {@html marked.parseInline(content.Byline)}
+    {:else if lang === 'es'}
+      🇪🇸 Por {@html marked.parseInline(content.Byline)}
+    {/if}
+  </span>
+  <div slot="dateline">
+    {#if lang === 'es'}
+      🇪🇸 Publicado <time datetime="{content.Published}">
+        {new Date(content.Published).toLocaleString('es-ES', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })}</time
+      >
+    {:else}
+      Published <time datetime="{content.Published}">
+        {apdate(new Date(content.Published))}</time
+      >
+    {/if}
+  </div>
+</Headline>
+```
+
+## Note on uploading to RNGS
+
+In this rig, we no longer upload and publish separate packs for translated interactive pages. To share translated pages, simply add the `lang` prop at the end of the URl.
+
+For example, if this is the URL for the English interactive page:
+`https://www.reuters.com/graphics/PERU-PROTEST/ROADBLOCK/zgpobnbwavd/`
+
+Then the Spanish one is:
+`https://www.reuters.com/graphics/PERU-PROTEST/ROADBLOCK/zgpobnbwavd/es/`
 
 ## Other options
 


### PR DESCRIPTION
# What's in this PR
- Adds section on how to set up `google.json`
- Makes sure all examples are up to date
- Rename file names to match our rig
- Adds section on translating byline/dateline 


@hobbes7878  -- if this looks good, I'll go ahead and add `export let lang = 'en'` to `App.svelte` in our bluprint. Let me know what you think